### PR TITLE
[feat] uniform length timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,30 @@ so might result in unexpected ordering, as emphasised by the example below.
 
 level-tier will warn if using numbers as namespace keys.
 
+## Uniform length timestamp padding
+
+level-tier includes a convenience method that produces uniform length timestamps.
+
+```js
+  leveltier.now();
+
+  // Date.now() :        1575146509497
+  // level.now(): 00000001575146509497
+```
+
+This function also accepts a timestamp to pad when creating a range Key. 
+Putting this together, writing and retrieval would look like this
+
+```js
+    // writing data
+      const key = leveltier(['data', leveltier.now()])
+      mydb.put(key, data)
+    
+    // retrieving data after some lower bound
+      const startkey = leveltier.gte(['data', leveltier.now({timestamp:1575156550378})])
+      mydb.createReadStream({gt:startkey})
+```
+
 ## Important note
 
 This module is a minimalistic and naive implementation namespacing

--- a/index.js
+++ b/index.js
@@ -32,4 +32,15 @@ leveltier.parse = function(key) {
   return key.split(LOWER_BOUND);
 }
 
+leveltier.now = function({ maxLength = 20, timestamp } =  {}) {
+  const now = timestamp && timestamp.toString() || Date.now().toString();
+  const padAmt = maxLength - now.length;
+  if (padAmt < 0) {
+    throw new Error(
+      `Timestamp maxLength not long enough. Provide a value greater than ${maxLength}.`
+    );
+  }
+  return "0".repeat(padAmt).concat(now);
+}
+
 module.exports = leveltier;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "level-tier",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Minimalistic LevelUP utility for namespacing keys.",
   "main": "index.js",
   "directories": {

--- a/test/level-tier.js
+++ b/test/level-tier.js
@@ -93,4 +93,34 @@ describe('level-tier', function() {
       expect(leveltier.parse(key)).to.eql(tiers);
     });
   });
+
+  describe("now padding", function() {
+    it("should pad timestamps", function() {
+      const now = Date.now();
+      const lNow = leveltier.now();
+      expect(lNow).to.not.eql(now.toString());
+      expect(lNow.length).to.eql(20);
+    });
+
+    it("should pad timestamps uniformly", function() {
+      const now = Date.now().toString();
+      const now2 = now.concat("29");
+      const lNow = leveltier.now({ timestamp: now });
+      const lNow2 = leveltier.now({ timestamp: now2 });
+
+      expect(lNow.length).to.eql(lNow2.length);
+    });
+
+    it("should throw when timestamp length exceeds maxLength", function() {
+      expect(() => {
+        leveltier.now({
+          timestamp: Date.now()
+            .toString()
+            .concat("3".repeat(20))
+        });
+      }).to.throwException(
+        /Timestamp maxLength not long enough. Provide a value greater than 20./
+      );
+    });
+  });
 });


### PR DESCRIPTION
produces uniform length timestamps with 

```js
    leveltier.now()
```
Sorry for the delay!